### PR TITLE
Fix af spawnkills

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,10 +29,11 @@ var spawnHandler = new SpawnHandler();
 var gameRunning = false;
 var startTime;
 var roundNumber = 0;
-var roundTime = 30000;
+var roundTime = 33000;
 
 var players = {};
 var asteroids = [];
+var timer = 0;
 
 var io = require('socket.io')(serv,{});
 io.sockets.on('connection', function(socket){
@@ -70,7 +71,7 @@ io.sockets.on('connection', function(socket){
 	});
 
 	socket.on('fire', function(){
-		if(players[socket.id].ship != null){
+		if(players[socket.id].ship != null  && timer < 30){
 			players[socket.id].ship.fire();
 		}
 	});
@@ -151,7 +152,6 @@ function rotateShip(player, angle){
 }
 
 function createUpdatePackage(world){
-	var timer = 0;
 	if(gameRunning)
 	{
 		timer = (roundTime-(Date.now()-startTime))/1000;

--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ io.sockets.on('connection', function(socket){
 	});
 
 	socket.on('fire', function(){
-		if(players[socket.id].ship != null  && timer < 30){
+		if(players[socket.id].ship != null  && timer <= 30){
 			players[socket.id].ship.fire();
 		}
 	});

--- a/ship.js
+++ b/ship.js
@@ -6,7 +6,7 @@ function Ship(color, pos){
 	this.pos = pos;
   this.frontPoint;
   this.drawPoints = [];
-  this.heading = 0;
+  this.heading = Math.floor(Math.random() * (Math.PI * 2));
   this.rotation = 0;
   this.velocity = {x: 0, y:0};
   this.isBoosting = false;


### PR DESCRIPTION
Start heading på alle skibe er nu random, så alle skibe ikke starter med at pege i røven på hinanden.

Skibe kan ikke skyde de første 3 sekunder af spillet for at undgå spawnkilling.
For at kompensere denne ændring er spilletiden forøget med 3 sek